### PR TITLE
スライダー表示時のスマホでの表示崩れ対応、他１件

### DIFF
--- a/Locale/eng/LC_MESSAGES/photo_albums.pot
+++ b/Locale/eng/LC_MESSAGES/photo_albums.pot
@@ -226,3 +226,5 @@ msgstr ""
 msgid "Change displayed alubum on %s"
 msgstr ""
 
+msgid "'0' for default setting."
+msgstr ""

--- a/Locale/jpn/LC_MESSAGES/photo_albums.po
+++ b/Locale/jpn/LC_MESSAGES/photo_albums.po
@@ -198,3 +198,6 @@ msgstr "表示されているアルバムは、%sで設定してください。"
 
 msgid "Slide photo height(px)"
 msgstr "スライド写真の高さ(px)"
+
+msgid "'0' for default setting."
+msgstr "「0」を指定すると自動になります"

--- a/Locale/photo_albums.pot
+++ b/Locale/photo_albums.pot
@@ -226,3 +226,5 @@ msgstr ""
 msgid "Change displayed alubum on %s"
 msgstr ""
 
+msgid "'0' for default setting."
+msgstr ""

--- a/View/Elements/frame_setting.ctp
+++ b/View/Elements/frame_setting.ctp
@@ -61,6 +61,7 @@
 							'div' => 'form-inline',
 							'min' => 10,
 							'max' => 10000,
+							'help' => __d('photo_albums', '\'0\' for default setting.'),
 							'ng-disabled' => 'FrameSettingController.checkDisplayTypeSlide == false',
 						)
 					);

--- a/View/PhotoAlbumPhotos/slide.ctp
+++ b/View/PhotoAlbumPhotos/slide.ctp
@@ -85,7 +85,10 @@ $srcPrefix = $this->Html->url(
 						if ($frameSetting['PhotoAlbumFrameSetting']['display_type'] == PhotoAlbumFrameSetting::DISPLAY_TYPE_SLIDE &&
 							isset($frameSetting['PhotoAlbumFrameSetting']['slide_height'])
 						) {
-							echo 'height:' . $frameSetting['PhotoAlbumFrameSetting']['slide_height'] . 'px';
+							// echo 'height:' . $frameSetting['PhotoAlbumFrameSetting']['slide_height'] . 'px';
+							echo 'max-height:' . $frameSetting['PhotoAlbumFrameSetting']['slide_height'] . 'px;';
+							list($width, $height) = getimagesize( WWW_ROOT . $photo['UploadFile']['photo']['path'] . $photo['UploadFile']['photo']['id'] . DS . $photo['UploadFile']['photo']['real_file_name']);
+							echo 'padding-top:' . ($height / $width * 100) . '%;';
 						}
 					?>
 				"

--- a/View/PhotoAlbumPhotos/slide.ctp
+++ b/View/PhotoAlbumPhotos/slide.ctp
@@ -85,10 +85,12 @@ $srcPrefix = $this->Html->url(
 						if ($frameSetting['PhotoAlbumFrameSetting']['display_type'] == PhotoAlbumFrameSetting::DISPLAY_TYPE_SLIDE &&
 							isset($frameSetting['PhotoAlbumFrameSetting']['slide_height'])
 						) {
-							// echo 'height:' . $frameSetting['PhotoAlbumFrameSetting']['slide_height'] . 'px';
-							echo 'max-height:' . $frameSetting['PhotoAlbumFrameSetting']['slide_height'] . 'px;';
-							list($width, $height) = getimagesize( WWW_ROOT . $photo['UploadFile']['photo']['path'] . $photo['UploadFile']['photo']['id'] . DS . $photo['UploadFile']['photo']['real_file_name']);
-							echo 'padding-top:' . ($height / $width * 100) . '%;';
+							if ($frameSetting['PhotoAlbumFrameSetting']['slide_height'] >= 1) {
+								echo 'height:' . $frameSetting['PhotoAlbumFrameSetting']['slide_height'] . 'px';
+							} else {
+								list($width, $height) = getimagesize( WWW_ROOT . $photo['UploadFile']['photo']['path'] . $photo['UploadFile']['photo']['id'] . DS . $photo['UploadFile']['photo']['real_file_name']);
+								echo 'padding-top:' . ($height / $width * 100) . '%;';
+							}
 						}
 					?>
 				"

--- a/webroot/css/photo_albums.css
+++ b/webroot/css/photo_albums.css
@@ -286,6 +286,14 @@
 .modal-content .carousel-indicators li > img {
 	display: block;
 }
+/* スライダー（carousel）の両側の影を消す */
+.carousel-control.right,
+.carousel-control.left{
+	background-image: -webkit-linear-gradient(left,rgba(0,0,0,.0001) 0,rgba(0,0,0,0) 100%);
+	background-image: -o-linear-gradient(left,rgba(0,0,0,.0001) 0,rgba(0,0,0,0) 100%);
+	background-image: -webkit-gradient(linear,left top,right top,from(rgba(0,0,0,0)),to(rgba(0,0,0,.5)));
+	background-image: linear-gradient(to right,rgba(0,0,0,.0001) 0,rgba(0,0,0,0) 100%);
+}
 
 .photo-albums-slide-modal-close {
 	position: absolute;

--- a/webroot/css/photo_albums.css
+++ b/webroot/css/photo_albums.css
@@ -226,7 +226,7 @@
 	left: 10%;
 }
 .photo-albums-slide-photo {
-	height: 400px;
+	/*height: 400px;*/
 	width: 100%;
 	background-repeat: no-repeat;
 	background-position: center center;


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/1164

仮修正のプルリクエストです。マージはまだ待ってください。

スマホでの表示崩れ対応していますが、この修正ですと高さ設定の扱いが微妙になるので、
高さ指定をどうするか、検討が必要です。

### スライダーの画像高さ設定（案）
・高さ設定とは別に、高さ自動設定という項目を１つ追加する。
・高さ設定をなくす。（高さ設定は自動）
・高さ設定の文言を修正する？（どんな文言が適当かはまだわからず）

とりあえず、現状こんな感じです。
