### PR TITLE
change: PhotoAlbumsにいくつかの改良を加えた

### DIFF
--- a/Controller/PhotoAlbumFrameSettingsController.php
+++ b/Controller/PhotoAlbumFrameSettingsController.php
@@ -100,6 +100,7 @@ class PhotoAlbumFrameSettingsController extends PhotoAlbumsAppController {
 			$this->NetCommons->handleValidationError($this->PhotoAlbumFrameSetting->validationErrors);
 		} else {
 			$this->request->data = $this->PhotoAlbumFrameSetting->getFrameSetting();
+			$this->request->data['Frame'] = Current::read('Frame');
 		}
 
 		$query = array(

--- a/Controller/PhotoAlbumPhotosController.php
+++ b/Controller/PhotoAlbumPhotosController.php
@@ -155,11 +155,12 @@ class PhotoAlbumPhotosController extends PhotoAlbumsAppController {
  */
 	public function add() {
 		$this->view = 'edit';
+		$this->set('isAdd', true);
 
 		$photo = $this->PhotoAlbumPhoto->create();
 		if ($this->request->is('post')) {
 			$this->request->data['PhotoAlbumPhoto']['status'] = $this->Workflow->parseStatus();
-			if ($this->PhotoAlbumPhoto->savePhoto($this->request->data)) {
+			if ($this->PhotoAlbumPhoto->savePhotos($this->request->data)) {
 				$url = PhotoAlbumsSettingUtility::settingUrl(
 					array(
 						'plugin' => 'photo_albums',

--- a/Model/Behavior/OriginImageResizeBehavior.php
+++ b/Model/Behavior/OriginImageResizeBehavior.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * アップロードされた元画像をリサイズするビヘイビア
+ */
+
+App::uses('ModelBehavior', 'Model');
+
+/**
+ * Class OriginImageResizeBehavior
+ */
+final class OriginImageResizeBehavior extends ModelBehavior {
+
+/**
+ * @var UploadFile
+ */
+	private $__uploadFileModel;
+
+/**
+ * setup
+ *
+ * @param Model $model model
+ * @param array $config behavior setting
+ * @return void
+ */
+	public function setup(Model $model, $config = array()) {
+		$this->__guradBeforeLoadingAttachmentBehavior($model);
+
+		$this->settings[$model->alias] = $config;
+		parent::setup($model, $config);
+	}
+
+/**
+ * afterSave
+ *
+ * @param Model $model model
+ * @param bool $created created
+ * @param array $options options
+ * @return bool
+ */
+	public function afterSave(Model $model, $created, $options = array()) {
+		$setting = $this->settings[$model->alias];
+
+		$this->__uploadFileModel = ClassRegistry::init('Files.UploadFile');
+
+		foreach ($setting as $fieldName => $fieldSetting) {
+			$pluginKey = Inflector::underscore($model->plugin);
+			$uploadFile = $this->__uploadFileModel->getFile($pluginKey, $model->id, $fieldName);
+			$this->overwriteOriginFile($uploadFile, $fieldSetting['resizeImagePrefix'] . '_');
+		}
+
+		return parent::afterSave($model, $created, $options);
+	}
+
+/**
+ * 元ファイルをリサイズしたファイルで上書き
+ *
+ * @param array $uploadFile UploadFileデータ
+ * @param string $overwriteFilePrefix リサイズされた画像のprefix このprefixのついたファイルを元画像あつかいにする。
+ * @return array|false UploadFile::save()の結果
+ * @throws InternalErrorException
+ */
+	public function overwriteOriginFile(array $uploadFile, $overwriteFilePrefix) {
+		// 元ファイル削除
+		$originFilePath = $this->__uploadFileModel->getRealFilePath($uploadFile);
+
+		//  origin_resizeからprefix削除
+		$originResizePath = substr($originFilePath, 0, -1 * strlen($uploadFile['UploadFile']['real_file_name'])) .
+			$overwriteFilePrefix . $uploadFile['UploadFile']['real_file_name'];
+
+		if (! file_exists($originResizePath)) {
+			//リネームするファイルがなければ、そのままuploadFileを返す。
+			return $uploadFile;
+		}
+
+		unlink($originFilePath);
+		rename($originResizePath, $originFilePath);
+
+		//  uploadFileのsize更新
+		$stat = stat($originFilePath);
+		$uploadFile['UploadFile']['size'] = $stat['size'];
+		try {
+			$uploadFile = $this->__uploadFileModel->save(
+				$uploadFile,
+				['callbacks' => false, 'validate' => false]
+			);
+		} catch (Exception $e) {
+			throw new InternalErrorException('Failed Update UploadFile.size');
+		}
+		return $uploadFile;
+	}
+
+/**
+ * 事前にAttachmentBehaviorが読みこまれているか
+ *
+ * @param Model $model model
+ * @return void
+ * @throws CakeException
+ */
+	private function __guradBeforeLoadingAttachmentBehavior(Model $model) {
+		if (!$model->Behaviors->loaded('Files.Attachment')) {
+			$error = '"Files.AttachmentBehavior" not loaded in ' . $model->alias . '. ';
+			$error .= 'Load "Files.AttachmentBehavior" before loading "OriginImageResizeBehavior"';
+			throw new CakeException($error);
+		}
+	}
+
+}

--- a/Model/Behavior/OriginImageResizeBehavior.php
+++ b/Model/Behavior/OriginImageResizeBehavior.php
@@ -11,7 +11,7 @@ App::uses('ModelBehavior', 'Model');
 final class OriginImageResizeBehavior extends ModelBehavior {
 
 /**
- * @var UploadFile
+ * @var UploadFile UploadFile model
  */
 	private $__uploadFileModel;
 

--- a/Model/Behavior/OriginImageResizeBehavior.php
+++ b/Model/Behavior/OriginImageResizeBehavior.php
@@ -67,7 +67,12 @@ final class OriginImageResizeBehavior extends ModelBehavior {
 		$originFilePath = $this->__uploadFileModel->getRealFilePath($uploadFile);
 
 		//  origin_resizeからprefix削除
-		$originResizePath = substr($originFilePath, 0, -1 * strlen($uploadFile['UploadFile']['real_file_name'])) .
+		$directoryPath = substr(
+			$originFilePath,
+			0,
+			-1 * strlen($uploadFile['UploadFile']['real_file_name'])
+		);
+		$originResizePath = $directoryPath .
 			$overwriteFilePrefix . $uploadFile['UploadFile']['real_file_name'];
 
 		if (! file_exists($originResizePath)) {

--- a/Model/Behavior/OriginImageResizeBehavior.php
+++ b/Model/Behavior/OriginImageResizeBehavior.php
@@ -26,6 +26,9 @@ final class OriginImageResizeBehavior extends ModelBehavior {
 		$this->__guradBeforeLoadingAttachmentBehavior($model);
 
 		$this->settings[$model->alias] = $config;
+
+		$this->__uploadFileModel = ClassRegistry::init('Files.UploadFile');
+
 		parent::setup($model, $config);
 	}
 
@@ -39,8 +42,6 @@ final class OriginImageResizeBehavior extends ModelBehavior {
  */
 	public function afterSave(Model $model, $created, $options = array()) {
 		$setting = $this->settings[$model->alias];
-
-		$this->__uploadFileModel = ClassRegistry::init('Files.UploadFile');
 
 		foreach ($setting as $fieldName => $fieldSetting) {
 			$pluginKey = Inflector::underscore($model->plugin);

--- a/Model/Behavior/OriginImageResizeBehavior.php
+++ b/Model/Behavior/OriginImageResizeBehavior.php
@@ -46,7 +46,9 @@ final class OriginImageResizeBehavior extends ModelBehavior {
 		foreach ($setting as $fieldName => $fieldSetting) {
 			$pluginKey = Inflector::underscore($model->plugin);
 			$uploadFile = $this->__uploadFileModel->getFile($pluginKey, $model->id, $fieldName);
-			$this->overwriteOriginFile($uploadFile, $fieldSetting['resizeImageSizeKey'] . '_');
+			if ($uploadFile) {
+				$this->overwriteOriginFile($uploadFile, $fieldSetting['resizeImageSizeKey'] . '_');
+			}
 		}
 
 		return parent::afterSave($model, $created, $options);

--- a/Model/Behavior/OriginImageResizeBehavior.php
+++ b/Model/Behavior/OriginImageResizeBehavior.php
@@ -45,7 +45,7 @@ final class OriginImageResizeBehavior extends ModelBehavior {
 		foreach ($setting as $fieldName => $fieldSetting) {
 			$pluginKey = Inflector::underscore($model->plugin);
 			$uploadFile = $this->__uploadFileModel->getFile($pluginKey, $model->id, $fieldName);
-			$this->overwriteOriginFile($uploadFile, $fieldSetting['resizeImagePrefix'] . '_');
+			$this->overwriteOriginFile($uploadFile, $fieldSetting['resizeImageSizeKey'] . '_');
 		}
 
 		return parent::afterSave($model, $created, $options);

--- a/Model/PhotoAlbum.php
+++ b/Model/PhotoAlbum.php
@@ -379,6 +379,11 @@ class PhotoAlbum extends PhotoAlbumsAppModel {
 				throw new InternalErrorException(__d('net_commons', 'Internal Server Error'));
 			}
 
+			if (!$this->__deleteJacketFile($data['PhotoAlbum']['key'])) {
+				throw new InternalErrorException(__d('net_commons', 'Internal Server Error'));
+			}
+
+			// アルバム内の写真削除
 			$Photo = ClassRegistry::init('PhotoAlbums.PhotoAlbumPhoto');
 			$conditions = array('PhotoAlbumPhoto.album_key' => $data['PhotoAlbum']['key']);
 			$query = array(
@@ -387,7 +392,11 @@ class PhotoAlbum extends PhotoAlbumsAppModel {
 				'recursive' => -1
 			);
 			$contentKeys = $Photo->find('list', $query);
+
 			if (!$Photo->deleteAll($conditions, false)) {
+				throw new InternalErrorException(__d('net_commons', 'Internal Server Error'));
+			}
+			if (!$Photo->deleteUploadFileByContentKeys($contentKeys)) {
 				throw new InternalErrorException(__d('net_commons', 'Internal Server Error'));
 			}
 
@@ -407,5 +416,15 @@ class PhotoAlbum extends PhotoAlbumsAppModel {
 		}
 
 		return true;
+	}
+
+/**
+ * __deleteJacketFile
+ *
+ * @param string $albumKey album.key
+ * @return mixed
+ */
+	private function __deleteJacketFile($albumKey) {
+		return $this->deleteUploadFileByContentKeys([$albumKey]);
 	}
 }

--- a/Model/PhotoAlbumPhoto.php
+++ b/Model/PhotoAlbumPhoto.php
@@ -157,7 +157,7 @@ class PhotoAlbumPhoto extends PhotoAlbumsAppModel {
  * @param array $data CakeRequest::data
  * @return bool
  */
-	protected function __savePhotos(array $data) {
+	private function __savePhotos(array $data) {
 		$base = $data;
 
 		foreach ($data[$this->alias][self::ATTACHMENT_FIELD_NAME] as $photo) {

--- a/Model/PhotoAlbumPhoto.php
+++ b/Model/PhotoAlbumPhoto.php
@@ -1,4 +1,4 @@
-<?php /** @noinspection ALL */
+<?php
 /**
  * PhotoAlbumPhoto Model
  *
@@ -36,12 +36,18 @@ class PhotoAlbumPhoto extends PhotoAlbumsAppModel {
 		'Files.Attachment' => [
 			PhotoAlbumPhoto::ATTACHMENT_FIELD_NAME => [
 				'thumbnailSizes' => array(
+					'origin' => '800ml',
 					'big' => '800ml',
 					'medium' => '400ml',
 					'small' => '152mh',
 					//'small' => '200ml',
 					'thumb' => '80x80',
 				),
+			]
+		],
+		'PhotoAlbums.OriginImageResize' => [
+			PhotoAlbumPhoto::ATTACHMENT_FIELD_NAME => [
+				'resizeImagePrefix' => 'origin',
 			]
 		],
 		'Workflow.Workflow',

--- a/Model/PhotoAlbumPhoto.php
+++ b/Model/PhotoAlbumPhoto.php
@@ -127,6 +127,46 @@ class PhotoAlbumPhoto extends PhotoAlbumsAppModel {
 	}
 
 /**
+ * savePhotos 複数ファイル保存
+ *
+ * @param array $data CakeRequest::data
+ * @return bool
+ */
+	public function savePhotos(array $data) {
+		$this->begin();
+
+		try {
+			if (!$this->__savePhotos($data)) {
+				$this->rollback();
+				return false;
+			};
+		} catch (Exception $ex) {
+			$this->rollback($ex);
+		}
+
+		$this->commit();
+		return true;
+	}
+
+/**
+ * 複数ファイル保存のメイン処理
+ *
+ * @param array $data CakeRequest::data
+ * @return bool
+ */
+	protected function __savePhotos(array $data) {
+		$base = $data;
+
+		foreach ($data[$this->alias][self::ATTACHMENT_FIELD_NAME] as $photo) {
+			$base[$this->alias][self::ATTACHMENT_FIELD_NAME] = $photo;
+			if (!$this->savePhoto($base)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+/**
  * Save photo
  *
  * @param array $data received post data
@@ -141,9 +181,7 @@ class PhotoAlbumPhoto extends PhotoAlbumsAppModel {
 		$photo = array();
 
 		foreach ($regenerateData as $index => $data) {
-			if ($index > 0) {
-				$this->create();
-			}
+			$this->create();
 
 			$this->set($data);
 			if (!$this->validates()) {
@@ -325,7 +363,7 @@ class PhotoAlbumPhoto extends PhotoAlbumsAppModel {
 /**
  * 隠しファイル除外
  *
- * @param array $files
+ * @param array $files ファイルリスト
  * @return array
  */
 	private function __excludeHiddenFile(array $files) {

--- a/Model/PhotoAlbumPhoto.php
+++ b/Model/PhotoAlbumPhoto.php
@@ -181,12 +181,10 @@ class PhotoAlbumPhoto extends PhotoAlbumsAppModel {
 
 		$regenerateData = $this->__regenerateDataForZip($data);
 
-		$photo = array();
-
-		foreach ($regenerateData as $index => $data) {
+		foreach ($regenerateData as $datum) {
 			$this->create();
 
-			$this->set($data);
+			$this->set($datum);
 			if (!$this->validates()) {
 				$this->rollback();
 				return false;
@@ -197,16 +195,16 @@ class PhotoAlbumPhoto extends PhotoAlbumsAppModel {
 				if (! $result) {
 					throw new InternalErrorException(__d('net_commons', 'Internal Server Error'));
 				}
-				$photo[] = $result;
 
 			} catch (Exception $ex) {
 				$this->rollback($ex);
+				return false;
 			}
 		}
 
 		$this->commit();
 
-		return $photo;
+		return true;
 	}
 
 /**

--- a/Model/PhotoAlbumPhoto.php
+++ b/Model/PhotoAlbumPhoto.php
@@ -39,8 +39,9 @@ class PhotoAlbumPhoto extends PhotoAlbumsAppModel {
 					'origin' => '800ml',
 					'big' => '800ml',
 					'medium' => '400ml',
-					'small' => '152mh',
-					//'small' => '200ml',
+					//'small' => '152mh',
+					'small' => '120mh',
+					////'small' => '200ml',
 					'thumb' => '80x80',
 				),
 			]

--- a/Model/PhotoAlbumPhoto.php
+++ b/Model/PhotoAlbumPhoto.php
@@ -47,7 +47,7 @@ class PhotoAlbumPhoto extends PhotoAlbumsAppModel {
 		],
 		'PhotoAlbums.OriginImageResize' => [
 			PhotoAlbumPhoto::ATTACHMENT_FIELD_NAME => [
-				'resizeImagePrefix' => 'origin',
+				'resizeImageSizeKey' => 'origin',
 			]
 		],
 		'Workflow.Workflow',

--- a/Model/PhotoAlbumPhoto.php
+++ b/Model/PhotoAlbumPhoto.php
@@ -33,8 +33,17 @@ class PhotoAlbumPhoto extends PhotoAlbumsAppModel {
  */
 	public $actsAs = array(
 		'NetCommons.OriginalKey',
-		// TODO サムネイルにあわせてsmallのサイズをきめる。
-		'Files.Attachment' => [PhotoAlbumPhoto::ATTACHMENT_FIELD_NAME],
+		'Files.Attachment' => [
+			PhotoAlbumPhoto::ATTACHMENT_FIELD_NAME => [
+				'thumbnailSizes' => array(
+					'big' => '800ml',
+					'medium' => '400ml',
+					'small' => '152mh',
+					//'small' => '200ml',
+					'thumb' => '80x80',
+				),
+			]
+		],
 		'Workflow.Workflow',
 		'Workflow.WorkflowComment',
 		//多言語

--- a/View/Helper/PhotoAlbumsImageHelper.php
+++ b/View/Helper/PhotoAlbumsImageHelper.php
@@ -87,6 +87,47 @@ class PhotoAlbumsImageHelper extends AppHelper {
 	}
 
 /**
+ * is_active: trueだったらinlineイメージにして、is_active:falseならURLをかえす
+ *
+ * @param array $data PhotoAlbumAlbumPhoto data
+ * @param string $size thumb, small, medium, big
+ * @return string
+ */
+	public function inlinePhotoIfActiveOtherwisePhotoUrl($data, $size = null) {
+		if ($data['PhotoAlbumPhoto']['is_active']) {
+			return $this->__inlinePhoto($data, $size);
+		}
+		return $this->photoUrl($data, $size);
+	}
+
+/**
+ * インライン画像
+ *
+ * @param array $data PhotoAlbumAlbumPhoto data
+ * @param string $size thumb, small, medium, big
+ * @return string
+ */
+	private function __inlinePhoto($data, $size = null) {
+		/** @var UploadFile $uploadFile */
+		$uploadFile = ClassRegistry::init("Files.UploadFile");
+		$file = $uploadFile->getFile(
+			'photo_albums',
+			$data['PhotoAlbumPhoto']['id'],
+			PhotoAlbumPhoto::ATTACHMENT_FIELD_NAME
+		);
+		if (!$file) {
+			return '';
+		}
+		$filepath = UPLOADS_ROOT . $file['UploadFile']['path'] . DS . $file['UploadFile']['id'] .DS . $size . '_' . $file['UploadFile']['real_file_name'];
+		if (file_exists($filepath) === false) {
+			return '';
+		}
+		$mimeType = $file['UploadFile']['mimetype'];
+		$encodeData = base64_encode(file_get_contents($filepath));
+		return sprintf('data:%s;base64,%s', $mimeType, $encodeData);
+	}
+
+/**
  * Creates photo image url array
  *
  * @param array $data PhotoAlbumAlbumPhoto data

--- a/View/Helper/PhotoAlbumsImageHelper.php
+++ b/View/Helper/PhotoAlbumsImageHelper.php
@@ -118,7 +118,11 @@ class PhotoAlbumsImageHelper extends AppHelper {
 		if (!$file) {
 			return '';
 		}
-		$filepath = UPLOADS_ROOT . $file['UploadFile']['path'] . DS . $file['UploadFile']['id'] .DS . $size . '_' . $file['UploadFile']['real_file_name'];
+		$filepath = UPLOADS_ROOT .
+			$file['UploadFile']['path'] . DS .
+			$file['UploadFile']['id'] . DS .
+			$size . '_' . $file['UploadFile']['real_file_name'];
+
 		if (file_exists($filepath) === false) {
 			return '';
 		}

--- a/View/PhotoAlbumPhotos/edit.ctp
+++ b/View/PhotoAlbumPhotos/edit.ctp
@@ -40,13 +40,28 @@
 			<?php echo $this->NetCommonsForm->hidden('status'); ?>
 
 			<?php
+			if (!empty($isAdd)) {
+				$this->Form->unlockField('PhotoAlbumPhoto.' . PhotoAlbumPhoto::ATTACHMENT_FIELD_NAME);
+				// バリデーションエラーが表示されるようにフィールド名はモデルフィールド名のままで、name属性で複数可能なフィールド指定
+				echo $this->NetCommonsForm->uploadFile(
+					'PhotoAlbumPhoto.' . PhotoAlbumPhoto::ATTACHMENT_FIELD_NAME ,
+					array(
+						'label' => __d('photo_albums', 'Photo file'),
+						'required' => true,
+						'multiple',
+						'name' => 'data[PhotoAlbumPhoto][photo][]',
+					)
+				);
+			} else {
 				echo $this->NetCommonsForm->uploadFile(
 					PhotoAlbumPhoto::ATTACHMENT_FIELD_NAME,
 					array(
 						'label' => __d('photo_albums', 'Photo file'),
 						'remove' => false
 					)
-				)
+				);
+			}
+
 			?>
 
 			<?php

--- a/View/PhotoAlbumPhotos/edit.ctp
+++ b/View/PhotoAlbumPhotos/edit.ctp
@@ -41,10 +41,12 @@
 
 			<?php
 			if (!empty($isAdd)) {
-				$this->Form->unlockField('PhotoAlbumPhoto.' . PhotoAlbumPhoto::ATTACHMENT_FIELD_NAME);
+				$this->Form->unlockField(
+					'PhotoAlbumPhoto.' . PhotoAlbumPhoto::ATTACHMENT_FIELD_NAME
+				);
 				// バリデーションエラーが表示されるようにフィールド名はモデルフィールド名のままで、name属性で複数可能なフィールド指定
 				echo $this->NetCommonsForm->uploadFile(
-					'PhotoAlbumPhoto.' . PhotoAlbumPhoto::ATTACHMENT_FIELD_NAME ,
+					'PhotoAlbumPhoto.' . PhotoAlbumPhoto::ATTACHMENT_FIELD_NAME,
 					array(
 						'label' => __d('photo_albums', 'Photo file'),
 						'required' => true,

--- a/View/PhotoAlbumPhotos/index.ctp
+++ b/View/PhotoAlbumPhotos/index.ctp
@@ -118,7 +118,11 @@
 						?>
 					')">
 
-						<div class="photo-albums-photo" style="background-image:url(<?php echo $this->PhotoAlbumsImage->photoUrl($photo, 'medium'); ?>);"></div>
+						<div class="photo-albums-photo" style="background-image:url(<?php
+						echo $this->PhotoAlbumsImage->inlinePhotoIfActiveOtherwisePhotoUrl($photo, 'small');
+						//echo $this->PhotoAlbumsImage->inlinePhoto($photo, 'thumb');
+						//echo $this->PhotoAlbumsImage->photoUrl($photo, 'small');
+						?>);"></div>
 					</a>
 
 					<div class="photo-albums-photo-list-status">


### PR DESCRIPTION
- アルバム内の写真一覧をインライン画像に（is_active:trueのみ）（高速表示）
- アップロードされた元画像もbigと同じサイズにリサイズ（ディスク容量節約）
- 新規画像追加で複数画像アップロードを可能にした
- アルバム削除時にUploadFileや実ファイルが削除されなかったのを修正