### PR TITLE
fix:アルバムに公開以外の写真があると、アルバムリストに表示される写真枚数が正しく表示されなくなるのを修正

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ name: tests
 jobs:
   setup:
     name: setup
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Slack Notification on Start
         uses: rtCamp/action-slack-notify@v2.2.0
@@ -28,7 +28,7 @@ jobs:
   tests:
     name: tests
     needs: setup
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         php: [ '7.1', '7.2', '7.3', '7.4' ]
@@ -92,46 +92,53 @@ jobs:
           docker-compose exec -T nc3app bash /opt/scripts/app-build.sh
 
       - name: phpcs (PHP CodeSniffer)
+        if: always()
         run: |
           cd ${NC3_DOCKER_DIR}
           docker-compose exec -T nc3app bash /opt/scripts/phpcs.sh
 
       - name: phpmd (PHP Mess Detector)
+        if: always()
         run: |
           cd ${NC3_DOCKER_DIR}
           docker-compose exec -T nc3app bash /opt/scripts/phpmd.sh
 
       - name: phpcpd (PHP Copy/Paste Detector)
+        if: always()
         run: |
           cd ${NC3_DOCKER_DIR}
           docker-compose exec -T nc3app bash /opt/scripts/phpcpd.sh
 
       - name: gjslint (JavaScript Style Check)
+        if: always()
         run: |
           cd ${NC3_DOCKER_DIR}
           docker-compose exec -T nc3app bash /opt/scripts/gjslint.sh
 
       - name: phpdoc (PHP Documentor)
+        if: always()
         run: |
           cd ${NC3_DOCKER_DIR}
           docker-compose exec -T nc3app bash /opt/scripts/phpdoc.sh
 
       - name: phpunit (PHP UnitTest)
+        if: always()
         run: |
           cd ${NC3_DOCKER_DIR}
           docker-compose exec -T nc3app bash /opt/scripts/phpunit.sh
           sudo -s chmod a+w -R ${NC3_BUILD_DIR}/build
 
-      - name: push coveralls
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: ${{ matrix.php }}
-        run: |
-          cd ${NC3_BUILD_DIR}
-          ls -la ${NC3_BUILD_DIR}
-          vendors/bin/php-coveralls --coverage_clover=build/logs/clover.xml -v
+#       - name: push coveralls
+#         env:
+#           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#           COVERALLS_FLAG_NAME: ${{ matrix.php }}
+#         run: |
+#           cd ${NC3_BUILD_DIR}
+#           ls -la ${NC3_BUILD_DIR}
+#           vendors/bin/php-coveralls --coverage_clover=build/logs/clover.xml -v
 
       - name: docker-compose remove
+        if: always()
         run: |
           cd ${NC3_DOCKER_DIR}
           docker-compose rm -f

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,7 +155,7 @@ jobs:
 
   teardown:
     name: teardown
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: tests
     steps:
       # テスト成功時はこちらのステップが実行される

--- a/Model/PhotoAlbum.php
+++ b/Model/PhotoAlbum.php
@@ -128,9 +128,8 @@ class PhotoAlbum extends PhotoAlbumsAppModel {
 		$photoCount = [];
 		foreach ($countArr as $result) {
 			$result = $result['PhotoAlbumPhoto'];
-			$photoCount[$result['album_key']] = [
-				$result['status'] => $result['photo_count']
-			];
+			$photoCount[$result['album_key']][$result['status']] = $result['photo_count'];
+
 		}
 
 		foreach ($results as $index => $result) {


### PR DESCRIPTION
アルバムに差し戻しや承認待ちの写真があると、アルバム一覧に表示される写真数が正しく表示されなくなるのを修正。
アルバムリストに表示される「このアルバムにはこのアルバムには承認待ち写真：1枚 差戻し写真：1枚があります。」というようなメッセージも正しく表示されなかったが、この修正で正しく表示されるようになる。